### PR TITLE
make api key requried

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,2 +1,13 @@
 # Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+
+configSchema:
+  # JSON Schema defining the configuration options for the MCP.
+  type: "object"
+  required: ["scrapegraphApiKey"]
+  properties:
+    scrapegraphApiKey:
+      type: "string"
+      description: "Your Scrapegraph API key"
+
 runtime: "python"

--- a/src/scrapegraph_mcp/server.py
+++ b/src/scrapegraph_mcp/server.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, Optional, List, Union
 import httpx
 from fastmcp import Context, FastMCP
 from smithery.decorators import smithery
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, AliasChoices
 
 # Configure logging
 logging.basicConfig(
@@ -342,7 +342,11 @@ class ScapeGraphClient:
 class ConfigSchema(BaseModel):
     scrapegraph_api_key: Optional[str] = Field(
         default=None,
-        description="Your Scrapegraph API key (optional - can also be set via SGAI_API_KEY environment variable)"
+        description="Your Scrapegraph API key (optional - can also be set via SGAI_API_KEY environment variable)",
+        # Accept both camelCase (from smithery.yaml) and snake_case (internal) for validation,
+        # and serialize back to camelCase to match Smithery expectations.
+        validation_alias=AliasChoices("scrapegraphApiKey", "scrapegraph_api_key"),
+        serialization_alias="scrapegraphApiKey",
     )
 
 


### PR DESCRIPTION
Make api key mandatory from optional 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Require `scrapegraphApiKey` in Smithery config and align server config schema with camelCase via Pydantic aliases.
> 
> - **Config (Smithery)**:
>   - Add `configSchema` requiring `scrapegraphApiKey` (string) with description in `smithery.yaml`.
> - **Server (Pydantic schema)**:
>   - Import `AliasChoices` and update `ConfigSchema.scrapegraph_api_key` to accept `scrapegraphApiKey`/`scrapegraph_api_key` via `validation_alias` and serialize as `scrapegraphApiKey`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4579347d9d9eaf8287a40435c5b69c47a4bf2604. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->