### PR TITLE
add dockerfile to publish on docker mcp registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Use Python slim image
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Set Python unbuffered mode
+ENV PYTHONUNBUFFERED=1
+
+# Copy pyproject.toml and README.md first for better caching
+COPY pyproject.toml README.md ./
+
+# Copy the source code
+COPY src/ ./src/
+
+# Install the package and its dependencies from pyproject.toml
+RUN pip install --no-cache-dir .
+
+# Create non-root user
+RUN useradd -m -u 1000 mcpuser && \
+    chown -R mcpuser:mcpuser /app
+
+# Switch to non-root user
+USER mcpuser
+
+# Run the server
+CMD ["python", "-m", "scrapegraph_mcp.server"]
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a Dockerfile that builds a Python 3.11 image, installs the package, runs as non-root, and starts `scrapegraph_mcp.server`.
> 
> - **Docker**:
>   - Add `Dockerfile` based on `python:3.11-slim`.
>   - Copies `pyproject.toml`, `README.md`, and `src/`; installs package with `pip install .`.
>   - Sets `PYTHONUNBUFFERED=1`, creates non-root user `mcpuser`, and runs `python -m scrapegraph_mcp.server`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d15a93d055ed1b5b280e5370df139b9560ba1a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->