### PR TITLE
Add Remote Server Usage section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A production-ready [Model Context Protocol](https://modelcontextprotocol.io/intr
 - [Quick Start](#quick-start)
 - [Available Tools](#available-tools)
 - [Setup Instructions](#setup-instructions)
+- [Remote Server Usage](#remote-server-usage)
 - [Local Usage](#local-usage)
 - [Google ADK Integration](#google-adk-integration)
 - [Example Use Cases](#example-use-cases)
@@ -213,6 +214,53 @@ The configuration file is located at:
 Add the ScrapeGraphAI MCP server on the settings:
 
 ![Cursor MCP Integration](assets/cursor_mcp.png)
+
+## Remote Server Usage
+
+Connect to our hosted MCP server - no local installation required!
+
+### Claude Desktop Configuration (Remote)
+
+Add this to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "scrapegraph-mcp": {
+      "command": "npx",
+      "args": [
+        "mcp-remote@0.1.25",
+        "https://scrapegraph-mcp.onrender.com/mcp",
+        "--header",
+        "X-API-Key:YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+### Cursor Configuration (Remote)
+
+Cursor supports native HTTP MCP connections. Add to your Cursor MCP settings (`~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "scrapegraph-mcp": {
+      "url": "https://scrapegraph-mcp.onrender.com/mcp",
+      "headers": {
+        "X-API-Key": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Benefits of Remote Server
+
+- **No local setup** - Just configure and start using
+- **Always up-to-date** - Automatically receives latest updates
+- **Cross-platform** - Works on any OS with Node.js
 
 ## Local Usage
 


### PR DESCRIPTION
Working on claude and cursor

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/a5828200-a51d-4e38-83d2-468640260765" />

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/71aca98c-66a4-4bad-b3be-6fa605012c87" />


- Introduced a new section detailing how to connect to the hosted MCP server on Render.
- Provided configuration examples for Claude Desktop and Cursor, including JSON snippets.
- Highlighted benefits of using the remote server, such as no local setup and automatic updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Remote Server Usage section to README with Claude Desktop and Cursor config examples for the hosted MCP server and updates the TOC.
> 
> - **Documentation**:
>   - **Remote Server Usage**: Add new section in `README.md` detailing how to connect to the hosted MCP server.
>     - Claude Desktop: `npx mcp-remote@0.1.25 https://scrapegraph-mcp.onrender.com/mcp --header X-API-Key:...` config example.
>     - Cursor: native HTTP MCP config with `url` and `headers` JSON snippet.
>     - Benefits: no local setup, auto-updates, cross-platform.
>   - **TOC**: Add `Remote Server Usage` entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da8f4e4c2bb978bb6d38411932dcb665bf9aceae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->