### PR TITLE
docs: point remote MCP endpoint to mcp.scrapegraphai.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Add this to your Claude Desktop config (`~/Library/Application Support/Claude/cl
       "command": "npx",
       "args": [
         "mcp-remote@0.1.25",
-        "https://scrapegraph-mcp.onrender.com/mcp",
+        "https://mcp.scrapegraphai.com/mcp",
         "--header",
         "X-API-Key:YOUR_API_KEY"
       ]
@@ -186,7 +186,7 @@ Cursor supports native HTTP MCP connections. Add to your Cursor MCP settings (`~
 {
   "mcpServers": {
     "scrapegraph-mcp": {
-      "url": "https://scrapegraph-mcp.onrender.com/mcp",
+      "url": "https://mcp.scrapegraphai.com/mcp",
       "headers": {
         "X-API-Key": "YOUR_API_KEY"
       }


### PR DESCRIPTION
## What

Updates every reference to the hosted remote MCP server in the README from the legacy Render host to the official endpoint.

| Before | After |
|--------|-------|
| `https://scrapegraph-mcp.onrender.com/mcp` | `https://mcp.scrapegraphai.com/mcp` |

Affected: Claude Desktop (Remote) config and Cursor (Remote) config.

## Why

`https://mcp.scrapegraphai.com/mcp` is the live official remote MCP endpoint (verified: `initialize` + `tools/list` respond correctly, server `ScapeGraph API MCP Server v3.2.4`, 17 tools exposed over Streamable HTTP). The README still pointed users at the old `onrender.com` host.

## Verification

```
POST https://mcp.scrapegraphai.com/mcp  -> initialize OK (session id issued)
tools/list -> scrape, extract, search, schema, crawl_*, monitor_*, credits, history
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)