### PR TITLE
feat: send User-Agent header on API requests

### DIFF
--- a/src/scrapegraph_mcp/server.py
+++ b/src/scrapegraph_mcp/server.py
@@ -83,6 +83,7 @@ from pydantic import AliasChoices, BaseModel, Field
 from smithery.decorators import smithery
 from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 # Configure logging
 logging.basicConfig(
@@ -111,18 +112,18 @@ class BrowserRedirectMiddleware:
     ``/health`` endpoint are left untouched.
     """
 
-    def __init__(self, app, docs_url: str = DOCS_URL) -> None:
+    def __init__(self, app: ASGIApp, docs_url: str = DOCS_URL) -> None:
         self.app = app
         self.docs_url = docs_url
 
-    async def __call__(self, scope, receive, send) -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] == "http" and self._is_browser_navigation(scope):
             response = RedirectResponse(self.docs_url, status_code=302)
             await response(scope, receive, send)
             return
         await self.app(scope, receive, send)
 
-    def _is_browser_navigation(self, scope) -> bool:
+    def _is_browser_navigation(self, scope: Scope) -> bool:
         if scope["method"] not in ("GET", "HEAD"):
             return False
         if scope["path"].rstrip("/") != "":

--- a/src/scrapegraph_mcp/server.py
+++ b/src/scrapegraph_mcp/server.py
@@ -219,6 +219,7 @@ class ScapeGraphClient:
             "SGAI-APIKEY": api_key,
             "Content-Type": "application/json",
             "accept": "application/json",
+            "User-Agent": f"scrapegraph-mcp/{MCP_SERVER_VERSION}",
             "X-SDK-Version": f"scrapegraph-mcp@{MCP_SERVER_VERSION}",
         }
         self.client = httpx.Client(timeout=httpx.Timeout(_api_timeout_s()))


### PR DESCRIPTION
## What

Adds a `User-Agent: scrapegraph-mcp/<version>` header to `ScapeGraphClient.headers`, sent alongside the existing `SGAI-APIKEY` / `X-SDK-Version` headers on every API request.

## Why

Lets the ScrapeGraphAI API attribute traffic originating from the MCP server (telemetry / debugging / routing), matching the equivalent change in the hosted MCP (sgai-stack `apps/mcp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)