### PR TITLE
docs: replace broken Smithery badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
-[![smithery badge](https://smithery.ai/badge/@ScrapeGraphAI/scrapegraph-mcp)](https://smithery.ai/server/@ScrapeGraphAI/scrapegraph-mcp)
+[![LightNow](https://lightnow.ai/badge/io.github.ScrapeGraphAI/scrapegraph-mcp)](https://lightnow.ai/servers/io.github.ScrapeGraphAI/scrapegraph-mcp)
 
 
 A production-ready [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) server that provides seamless integration with the [ScrapeGraph AI](https://scrapegraphai.com) API. This server enables language models to leverage advanced AI-powered web scraping capabilities with enterprise-grade reliability.


### PR DESCRIPTION
## Summary

Replaces the broken Smithery badge with the matching LightNow capability badge.

- Server: https://lightnow.ai/servers/io.github.ScrapeGraphAI/scrapegraph-mcp
- Badge docs and variants: https://docs.lightnow.ai/how-to/add-capability-badge/

## Validation

- Verified the badge SVG and server page return successfully.